### PR TITLE
fix bug in autocomplete when project is selected

### DIFF
--- a/src/pages/Compensation.jsx
+++ b/src/pages/Compensation.jsx
@@ -332,7 +332,7 @@ class Compensation extends Component {
   }
 
   innerElementChange = (parent, projectId) => {
-    this.loadProject(projectId);
+    this.loadProject(typeof projectId === 'object' ? projectId.id_project : projectId);
   }
 
   /** ********************************* */


### PR DESCRIPTION
When using autocomplete the projectId returned was an object instead of number then proper parameter type was taken for both cases button and autocomplete. 