### PR TITLE
Fix route deleting a extra slash in /connectivity/current/se endpoint in RestAPI

### DIFF
--- a/src/pages/search/drawer/Landscape.jsx
+++ b/src/pages/search/drawer/Landscape.jsx
@@ -90,8 +90,6 @@ class Landscape extends React.Component {
         label: {
           id: 'connectivity',
           name: 'Conectividad de Áreas Protegidas',
-          disabled: true,
-          collapsed: true,
         },
         component: PAConnectivity,
         componentProps: { handlerAccordionGeometry: this.handlerAccordionGeometry },

--- a/src/utils/restAPI.js
+++ b/src/utils/restAPI.js
@@ -344,7 +344,7 @@ class RestAPI {
    * @return {Promise<Object>} Array of objects with data of current PA connectivity by SE
    */
    static requestCurrentPAConnectivityBySE(areaType, areaId, seType) {
-    return RestAPI.makeGetRequest(`/connectivity/current/se?areaType=${areaType}&areaId=${areaId}&seType=${seType}`);
+    return RestAPI.makeGetRequest(`connectivity/current/se?areaType=${areaType}&areaId=${areaId}&seType=${seType}`);
   }
 
   /** ******************** */


### PR DESCRIPTION
Fix route deleting a extra slash in /connectivity/current/se endpoint in RestAPI