### PR TITLE
add Context Type to TimelinePAConnectivity component

### DIFF
--- a/src/pages/search/drawer/landscape/connectivity/TimelinePAConnectivity.jsx
+++ b/src/pages/search/drawer/landscape/connectivity/TimelinePAConnectivity.jsx
@@ -6,6 +6,7 @@ import InfoIcon from '@material-ui/icons/Info';
 import GraphLoader from 'components/charts/GraphLoader';
 import matchColor from 'utils/matchColor';
 import RestAPI from 'utils/restAPI';
+import SearchContext from 'pages/search/SearchContext';
 
 class TimelinePAConnectivity extends React.Component {
   mounted = false;
@@ -118,3 +119,5 @@ class TimelinePAConnectivity extends React.Component {
 }
 
 export default TimelinePAConnectivity;
+
+TimelinePAConnectivity.contextType = SearchContext;


### PR DESCRIPTION
This is linked to the pull request of endpointConnectivitySection2 in order to display the graph it is necessary to add the ContextType in the component.