### PR TITLE
add  y axis limit for TimelinePAConnectivity graph

### DIFF
--- a/src/components/charts/GraphLoader.jsx
+++ b/src/components/charts/GraphLoader.jsx
@@ -29,6 +29,7 @@ const GraphLoader = (props) => {
     markers,
     loading,
     selectedIndexValue,
+    yMax,
   } = props;
 
   // While data is being retrieved from server
@@ -161,6 +162,7 @@ const GraphLoader = (props) => {
           markers={markers}
           height={490}
           units={units}
+          yMax={yMax}
         />
       );
     default:

--- a/src/components/charts/GraphLoader.jsx
+++ b/src/components/charts/GraphLoader.jsx
@@ -183,6 +183,7 @@ GraphLoader.propTypes = {
   width: PropTypes.number,
   showOnlyTitle: PropTypes.bool,
   units: PropTypes.string,
+  yMax: PropTypes.number,
   elementOnClick: PropTypes.func,
   // TODO: Remove array type once the charts in compensation are migrated
   colors: PropTypes.oneOfType([
@@ -208,6 +209,7 @@ GraphLoader.defaultProps = {
   labelY: '',
   showOnlyTitle: false,
   units: '',
+  yMax: '',
   elementOnClick: () => {},
   colors: () => {},
   padding: 0.25,

--- a/src/components/charts/GraphLoader.jsx
+++ b/src/components/charts/GraphLoader.jsx
@@ -209,7 +209,7 @@ GraphLoader.defaultProps = {
   labelY: '',
   showOnlyTitle: false,
   units: '',
-  yMax: '',
+  yMax: 100,
   elementOnClick: () => {},
   colors: () => {},
   padding: 0.25,

--- a/src/pages/search/drawer/landscape/connectivity/TimelinePAConnectivity.jsx
+++ b/src/pages/search/drawer/landscape/connectivity/TimelinePAConnectivity.jsx
@@ -17,7 +17,6 @@ class TimelinePAConnectivity extends React.Component {
     this.state = {
       showInfoGraph: false,
       timelinePAConnectivity: [],
-      yLimit: 50,
     };
   }
 
@@ -84,7 +83,6 @@ class TimelinePAConnectivity extends React.Component {
     const {
       showInfoGraph,
       timelinePAConnectivity,
-      yLimit,
     } = this.state;
     return (
       <div className="graphcontainer pt6">
@@ -117,7 +115,7 @@ class TimelinePAConnectivity extends React.Component {
               labelX="Año"
               labelY="Porcentaje"
               units="%"
-              yMax={yLimit}
+              yMax={50}
             />
           </div>
         </div>

--- a/src/pages/search/drawer/landscape/connectivity/TimelinePAConnectivity.jsx
+++ b/src/pages/search/drawer/landscape/connectivity/TimelinePAConnectivity.jsx
@@ -17,6 +17,7 @@ class TimelinePAConnectivity extends React.Component {
     this.state = {
       showInfoGraph: false,
       timelinePAConnectivity: [],
+      yLimit: 50,
     };
   }
 
@@ -83,6 +84,7 @@ class TimelinePAConnectivity extends React.Component {
     const {
       showInfoGraph,
       timelinePAConnectivity,
+      yLimit,
     } = this.state;
     return (
       <div className="graphcontainer pt6">
@@ -115,6 +117,7 @@ class TimelinePAConnectivity extends React.Component {
               labelX="Año"
               labelY="Porcentaje"
               units="%"
+              yMax={yLimit}
             />
           </div>
         </div>


### PR DESCRIPTION
With this changes, the limit for y-axis (yMax) in timelinePAConnectivity graph is 50. The y-axis limit for HH remains as default value. 