### PR TITLE
add areaId parameter in NOS thresholds request

### DIFF
--- a/src/pages/search/drawer/species/richness/NumberOfSpecies.jsx
+++ b/src/pages/search/drawer/species/richness/NumberOfSpecies.jsx
@@ -70,7 +70,7 @@ class NumberOfSpecies extends React.Component {
 
     Promise.all([
       RestAPI.requestNumberOfSpecies(areaId, geofenceId, 'all'),
-      RestAPI.requestNSThresholds(areaId, 'all'),
+      RestAPI.requestNSThresholds(areaId, geofenceId, 'all'),
     ])
       .then(([values, thresholds]) => {
         const data = [];

--- a/src/utils/restAPI.js
+++ b/src/utils/restAPI.js
@@ -366,14 +366,15 @@ class RestAPI {
    * Get the thresholds for the number of species for the specified area type
    *
    * @param {String} areaType area type id, f.e. "ea", "states"
+   * @param {Number | String} areaId area id to request, f.e. "CRQ", 24
    * @param {String} group group to filter results
    *
    * @return {Promise<Object>} Array of objects with minimum and maximun number of observed and
    * inferred species
    */
-  static requestNSThresholds(areaType, group) {
+  static requestNSThresholds(areaType, areaId, group) {
     return RestAPI.makeGetRequest(
-      `richness/number-species/thresholds?areaType=${areaType}${group ? `&group=${group}` : ''}`,
+      `richness/number-species/thresholds?areaType=${areaType}&areaId=${areaId}${group ? `&group=${group}` : ''}`,
     );
   }
 


### PR DESCRIPTION
Related to changes made to the backend in the PR [Feature/number of species](https://github.com/PEM-Humboldt/biotablero-backend/pull/243) to fix functionality when adding areaId parameter to NOS threshold endpoint.