### PR TITLE
Feature/bug states and back icon

### DIFF
--- a/src/pages/Search.jsx
+++ b/src/pages/Search.jsx
@@ -908,7 +908,7 @@ class Search extends Component {
         () => {
           const { history } = this.props;
           const { selectedAreaType, selectedArea } = this.state;
-          if (selectedAreaType) {
+          if (selectedAreaType && selectedArea) {
             history.push(`?area_type=${selectedAreaType.id}&area_id=${selectedArea.id || selectedArea.name}`);
             setHeaderNames(selectedAreaType.name, selectedArea.name);
           }

--- a/src/pages/Search.jsx
+++ b/src/pages/Search.jsx
@@ -908,8 +908,10 @@ class Search extends Component {
         () => {
           const { history } = this.props;
           const { selectedAreaType, selectedArea } = this.state;
-          history.push(`?area_type=${selectedAreaType.id}&area_id=${selectedArea.id || selectedArea.name}`);
-          setHeaderNames(selectedAreaType.name, selectedArea.name);
+          if (selectedAreaType) {
+            history.push(`?area_type=${selectedAreaType.id}&area_id=${selectedArea.id || selectedArea.name}`);
+            setHeaderNames(selectedAreaType.name, selectedArea.name);
+          }
         },
       );
     }
@@ -968,6 +970,7 @@ class Search extends Component {
       'paramoPAConn',
       'dryForestPAConn',
       'wetlandPAConn',
+      'speciesRecordsGaps',
     ];
     this.setState((prevState) => {
       const newState = { ...prevState };

--- a/src/pages/Search.jsx
+++ b/src/pages/Search.jsx
@@ -908,10 +908,8 @@ class Search extends Component {
         () => {
           const { history } = this.props;
           const { selectedAreaType, selectedArea } = this.state;
-          if (selectedAreaType) {
             history.push(`?area_type=${selectedAreaType.id}&area_id=${selectedArea.id || selectedArea.name}`);
             setHeaderNames(selectedAreaType.name, selectedArea.name);
-          }
         },
       );
     }

--- a/src/pages/Search.jsx
+++ b/src/pages/Search.jsx
@@ -1098,7 +1098,6 @@ class Search extends Component {
                   }}
                   description={Description()}
                   areasData={areaList}
-                  expandedId={0}
                 />
               )}
               { selectedAreaTypeId && selectedAreaId && (selectedAreaTypeId !== 'se') && (

--- a/src/pages/Search.jsx
+++ b/src/pages/Search.jsx
@@ -908,8 +908,10 @@ class Search extends Component {
         () => {
           const { history } = this.props;
           const { selectedAreaType, selectedArea } = this.state;
+          if (selectedAreaType) {
             history.push(`?area_type=${selectedAreaType.id}&area_id=${selectedArea.id || selectedArea.name}`);
             setHeaderNames(selectedAreaType.name, selectedArea.name);
+          }
         },
       );
     }

--- a/src/pages/search/selector/SearchAreas.jsx
+++ b/src/pages/search/selector/SearchAreas.jsx
@@ -53,6 +53,7 @@ const SearchAreas = ({ areaList, onChange, onSelection }) => {
       id: geofence.id,
       name: geofence.name,
       disabled: (geofence.id === 'se'),
+      collapsed: true,
     },
     component: AreaAutocomplete,
     componentProps: {


### PR DESCRIPTION
NOTE:
In Accordion. If collapsed prop in component Didmount of an accordion comes in true a condition rejects the tab and search for next accordion. By default the first tab is expanded because when the first tab comes with collapsed in false it will be the default tab. In all tabs by default will expand the first. 
To avoid pa and listAreas tabs expanded at the same time (because both come with collapsed in false) when user returns with backIcon collapsed must be set in true by default in `SearchAreas.jsx`. In this way all tabs comes in collapsed true, when user leaves the section all tabs will be collpased avoiding the first tab to be expanded. 

