### PR TITLE
Hide Species tab for San Andres

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "biotablero",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",

--- a/src/pages/search/drawer/Species.jsx
+++ b/src/pages/search/drawer/Species.jsx
@@ -29,8 +29,12 @@ class Species extends React.Component {
           selected = ['richness', 'functionalDiversity'];
         }
         break;
-      case 'basinSubzones':
       case 'ea':
+        if (geofenceId !== 'CORALINA') {
+          selected = ['richness', 'functionalDiversity'];
+        }
+        break;
+        case 'basinSubzones':
         selected = ['richness', 'functionalDiversity'];
         break;
       default:

--- a/src/pages/search/drawer/Species.jsx
+++ b/src/pages/search/drawer/Species.jsx
@@ -15,17 +15,20 @@ class Species extends React.Component {
         richness: 'numberOfSpecies',
         functionalDiversity: 'tropicalDryForest',
       },
-      availableComponents: ['richness', 'functionalDiversity'],
+      availableComponents: [],
       functionalFlag: false,
     };
   }
 
   componentDidMount() {
-    const { areaId } = this.context;
-
+    const { areaId, geofenceId } = this.context;
     let selected = [];
     switch (areaId) {
       case 'states':
+        if (geofenceId !== '88') {
+          selected = ['richness', 'functionalDiversity'];
+        }
+        break;
       case 'basinSubzones':
       case 'ea':
         selected = ['richness', 'functionalDiversity'];

--- a/src/pages/search/drawer/species/richness/NumberOfSpecies.jsx
+++ b/src/pages/search/drawer/species/richness/NumberOfSpecies.jsx
@@ -346,7 +346,7 @@ class NumberOfSpecies extends React.Component {
           </div>
         </div>
         <div>
-          {message === 'no-data' && (
+          {(message === 'no-data' || message === 'loading') && (
             <GraphLoader
               message={message}
               data={[]}

--- a/src/pages/search/drawer/species/richness/SpeciesRecordsGaps.jsx
+++ b/src/pages/search/drawer/species/richness/SpeciesRecordsGaps.jsx
@@ -117,7 +117,6 @@ class SpeciesRecordsGaps extends React.Component {
           this.setState({
             concentration: data,
             messageConc: null,
-            bioticRegion: region,
             csvData: dataArray,
           });
         }


### PR DESCRIPTION
An other minor adjustments in messages.

To test second point of the issue, comment this [if](https://github.com/PEM-Humboldt/biotablero-frontend/blob/29445b96924765287be7aa50824bb6cd08f21943/src/pages/search/drawer/Species.jsx#L28)