### PR TITLE
period order search adjustment

### DIFF
--- a/src/pages/search/drawer/landscape/forest/ForestLossPersistence.tsx
+++ b/src/pages/search/drawer/landscape/forest/ForestLossPersistence.tsx
@@ -28,7 +28,7 @@ interface State {
 class ForestLossPersistence extends React.Component<Props, State> {
   mounted = false;
   flpController;
-  currentPeriod = "2016-2021";
+  currentPeriod = "2000-2005";
 
   constructor(props: Props) {
     super(props);


### PR DESCRIPTION
## 🛠️ Changes
The search for the period order was adjusted so that when the request was made to the back, the period corresponds to that of the graph.

## 📝 Associated issues
[Ajustar el orden de los periodos en el front](https://github.com/PEM-Humboldt/biotablero-frontend/issues/922)


